### PR TITLE
getPackagesWightSum fix in Transfer.java

### DIFF
--- a/docs/4_manualisteszt.md
+++ b/docs/4_manualisteszt.md
@@ -1,9 +1,16 @@
 # Manuális tesztek végrehajtása
 
 ## Feladat
-_(Egy-két bekezdés az elvégzett munkáról.)_
 
-_Képernyőkép_
-![](pic.png)
+A feladat során "exploratory testing"-et végeztem a kóddal, és a hozzá tartozó dokumentációval. Rendelkezésre állt egy Swagger dokumentáció az API-hoz, amelyet tüzetesen átolvasva néhány hibát vettem észre. Ezeket az Eredmények részben részletezem, valamint az Exploratory Testing című Issue-ban.
+
+Az API továbbá a tesztelés során a csomagról történő információ lekérés közben hibát dobott. Ennek okát a kódban megtaláltam, és a fent említett Issue-ban dokumentált pull requestben javítottam.
 
 ## Eredmények, tanulságok
+
+A feladat során a dokumentációban a következő hibákat vettem észre:
+- **Helyesírási hiba a Model-eknél:** "owner" helyett "ownder" szerepel a model-eknél.
+- **Inkonzisztencia a válaszok terén:** Vannak olyan hívások, amiknél az Unauthorized válasz dokumentálva van, míg másoknál nincs, pedig autentikációhoz vannak kötve.
+- **Félrevezető változó nevek:** A Vehicle osztály raktere x, y, z dimenziókkal van jellemezve, amelyek utalhatnak a jármű, és a raktér dimenzióira is egyaránt.
+
+Tanulságként azt vonnám le, hogy ez az API külön egy alkalmazáshoz készült, annak a szolgáltatásait elégíti ki, azonban néhány hard-code-olt konstans miatt, és a fent említett félrevezető változó nevek miatt nehézségeket okoz más hasonló kontextusú alkalmazásba beimplementálni.

--- a/src/main/java/hu/bme/aut/freelancer_spring/model/Transfer.java
+++ b/src/main/java/hu/bme/aut/freelancer_spring/model/Transfer.java
@@ -89,7 +89,7 @@ public class Transfer {
 
     private double getPackagesWeightSum() {
         return packages.stream()
-                .mapToDouble(Package::getWeight)
+                .mapToDouble(Package -> Package::getWeight)
                 .sum();
     }
 


### PR DESCRIPTION
### The Error:
The function: getPackagesWeightSum had a mapToDouble call with wrong argument.
The argument was: 

Package::getWeight
### The Fix:
Changed the argument to: 

Package -> Package::getWeight